### PR TITLE
gradle-cache ::  Add annotations option for clusterIP service

### DIFF
--- a/charts/gradle-cache/Chart.yaml
+++ b/charts/gradle-cache/Chart.yaml
@@ -3,7 +3,7 @@ name: gradle-cache
 description: |-
   Helm chart to deploy [gradle-cache](https://docs.gradle.com/build-cache-node/).
 type: application
-version: 0.0.7
+version: 0.0.8
 appVersion: "9.9"
 home: https://github.com/slamdev/helm-charts/tree/master/charts/gradle-cache
 icon: https://gradle.org/icon/favicon-32x32.png

--- a/charts/gradle-cache/README.md
+++ b/charts/gradle-cache/README.md
@@ -38,7 +38,7 @@ Helm chart to deploy [gradle-cache](https://docs.gradle.com/build-cache-node/).
 | securityContext | object | `{}` | specifies security settings for a container |
 | service.port | int | `80` | service port |
 | service.type | string | `"ClusterIP"` | service type |
-| service.annotations | object | `{}` | annotations to add to the service |
+| service.annotations | object | `{}` | annotations to add to the clusterIP service |
 | serviceAccount.annotations | object | `{}` | annotations to add to the service account |
 | serviceAccount.create | bool | `false` | specifies whether a service account should be created |
 | serviceAccount.name | string | `nil` | the name of the service account to use; if not set and create is true, a name is generated using the fullname template |

--- a/charts/gradle-cache/README.md
+++ b/charts/gradle-cache/README.md
@@ -38,6 +38,7 @@ Helm chart to deploy [gradle-cache](https://docs.gradle.com/build-cache-node/).
 | securityContext | object | `{}` | specifies security settings for a container |
 | service.port | int | `80` | service port |
 | service.type | string | `"ClusterIP"` | service type |
+| service.annotations | object | `{}` | annotations to add to the service |
 | serviceAccount.annotations | object | `{}` | annotations to add to the service account |
 | serviceAccount.create | bool | `false` | specifies whether a service account should be created |
 | serviceAccount.name | string | `nil` | the name of the service account to use; if not set and create is true, a name is generated using the fullname template |

--- a/charts/gradle-cache/templates/service.yaml
+++ b/charts/gradle-cache/templates/service.yaml
@@ -5,6 +5,10 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- include "gradle-cache.labels" . | nindent 4 }}
+  {{- with .Values.service.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
 spec:
   type: {{ .Values.service.type }}
   ports:

--- a/charts/gradle-cache/values.yaml
+++ b/charts/gradle-cache/values.yaml
@@ -39,6 +39,10 @@ service:
   type: ClusterIP
   # service.port -- service port
   port: 80
+  # service.annotations -- service annotations
+  annotations: {}
+    # app.k8s.io: gradle-cache
+    # example.kubernetes.io/internal: gradle.internal
 
 ingress:
   # ingress.enabled -- enables Ingress for gradle-cache


### PR DESCRIPTION
Enable the option to add annotations for the `clusterIP` service.