### PR TITLE
Fix docker-registry-proxy port

### DIFF
--- a/charts/docker-registry-proxy/templates/deployment.yaml
+++ b/charts/docker-registry-proxy/templates/deployment.yaml
@@ -30,7 +30,7 @@ spec:
           imagePullPolicy: {{ .Values.image.pullPolicy }}
           ports:
             - name: http
-              containerPort: 8081
+              containerPort: 3128
               protocol: TCP
           livenessProbe:
             {{- toYaml .Values.livenessProbe | nindent 12 }}


### PR DESCRIPTION
Source: 
1) https://github.com/rpardini/docker-registry-proxy/blob/0.6.4/README.md#usage-running-the-proxy-server
2) "Expose port 3128 to the network"
