### PR TITLE
Upgrade altinity-clickhouse-operator to 0.16.1

### DIFF
--- a/charts/altinity-clickhouse-operator/Chart.yaml
+++ b/charts/altinity-clickhouse-operator/Chart.yaml
@@ -7,7 +7,7 @@ description: |-
 
   Refer to operator repo for additional information.
 type: application
-version: 0.0.7
+version: 0.0.11
 appVersion: 0.16.1
 home: https://github.com/slamdev/helm-charts/tree/master/charts/altinity-clickhouse-operator
 icon: https://artifacthub.io/image/2d6aa29c-c74f-4bff-bede-ba7e6e0315a7@2x

--- a/charts/altinity-clickhouse-operator/Chart.yaml
+++ b/charts/altinity-clickhouse-operator/Chart.yaml
@@ -8,7 +8,7 @@ description: |-
   Refer to operator repo for additional information.
 type: application
 version: 0.0.7
-appVersion: 0.16.0
+appVersion: 0.16.1
 home: https://github.com/slamdev/helm-charts/tree/master/charts/altinity-clickhouse-operator
 icon: https://artifacthub.io/image/2d6aa29c-c74f-4bff-bede-ba7e6e0315a7@2x
 maintainers:

--- a/charts/altinity-clickhouse-operator/crds/CustomResourceDefinition-clickhouseinstallations.clickhouse.altinity.com.yaml
+++ b/charts/altinity-clickhouse-operator/crds/CustomResourceDefinition-clickhouseinstallations.clickhouse.altinity.com.yaml
@@ -71,6 +71,8 @@ spec:
           description: Client access endpoint
           priority: 1
           jsonPath: .status.endpoint
+      subresources:
+        status: {}
       schema:
         openAPIV3Schema:
           description: define a set of Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more ClickHouse clusters
@@ -89,7 +91,95 @@ spec:
             status:
               type: object
               description: Current ClickHouseInstallation manifest status, contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other
-              x-kubernetes-preserve-unknown-fields: true
+              properties:
+                version:
+                  type: string
+                  description: Version
+                clusters:
+                  type: integer
+                  minimum: 0
+                  description: Clusters count
+                shards:
+                  type: integer
+                  minimum: 0
+                  description: Shards count
+                replicas:
+                  type: integer
+                  minimum: 0
+                  description: Replicas count
+                hosts:
+                  type: integer
+                  minimum: 0
+                  description: Hosts count
+                status:
+                  type: string
+                  description: Status
+                taskID:
+                  type: string
+                  description: Current task id
+                taskIDsStarted:
+                  type: array
+                  description: Started task ids
+                  items:
+                    type: string
+                taskIDsCompleted:
+                  type: array
+                  description: Completed task ids
+                  items:
+                    type: string
+                action:
+                  type: string
+                  description: Action
+                actions:
+                  type: array
+                  description: Actions
+                  items:
+                    type: string
+                error:
+                  type: string
+                  description: Last error
+                errors:
+                  type: array
+                  description: Errors
+                  items:
+                    type: string
+                updated:
+                  type: integer
+                  minimum: 0
+                  description: Updated Hosts count
+                added:
+                  type: integer
+                  minimum: 0
+                  description: Added Hosts count
+                deleted:
+                  type: integer
+                  minimum: 0
+                  description: Deleted Hosts count
+                delete:
+                  type: integer
+                  minimum: 0
+                  description: About to delete Hosts count
+                pods:
+                  type: array
+                  description: Pods
+                  items:
+                    type: string
+                fqdns:
+                  type: array
+                  description: Pods FQDNs
+                  items:
+                    type: string
+                endpoint:
+                  type: string
+                  description: Endpoint
+                generation:
+                  type: integer
+                  minimum: 0
+                  description: Generation
+                normalized:
+                  type: object
+                  description: Normalized CHI
+                  x-kubernetes-preserve-unknown-fields: true
             spec:
               type: object
               description: |

--- a/charts/altinity-clickhouse-operator/crds/CustomResourceDefinition-clickhouseinstallationtemplates.clickhouse.altinity.com.yaml
+++ b/charts/altinity-clickhouse-operator/crds/CustomResourceDefinition-clickhouseinstallationtemplates.clickhouse.altinity.com.yaml
@@ -71,9 +71,11 @@ spec:
           description: Client access endpoint
           priority: 1
           jsonPath: .status.endpoint
+      subresources:
+        status: {}
       schema:
         openAPIV3Schema:
-          description: define a template which describe Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more ClickHouse clusters, would be used in `chi.spec.useTemplates`
+          description: define a set of Kubernetes resources (StatefulSet, PVC, Service, ConfigMap) which describe behavior one or more ClickHouse clusters
           type: object
           required:
             - spec
@@ -89,7 +91,95 @@ spec:
             status:
               type: object
               description: Current ClickHouseInstallation manifest status, contains many fields like a normalized configuration, clickhouse-operator version, current action and all applied action list, current taskID and all applied taskIDs and other
-              x-kubernetes-preserve-unknown-fields: true
+              properties:
+                version:
+                  type: string
+                  description: Version
+                clusters:
+                  type: integer
+                  minimum: 0
+                  description: Clusters count
+                shards:
+                  type: integer
+                  minimum: 0
+                  description: Shards count
+                replicas:
+                  type: integer
+                  minimum: 0
+                  description: Replicas count
+                hosts:
+                  type: integer
+                  minimum: 0
+                  description: Hosts count
+                status:
+                  type: string
+                  description: Status
+                taskID:
+                  type: string
+                  description: Current task id
+                taskIDsStarted:
+                  type: array
+                  description: Started task ids
+                  items:
+                    type: string
+                taskIDsCompleted:
+                  type: array
+                  description: Completed task ids
+                  items:
+                    type: string
+                action:
+                  type: string
+                  description: Action
+                actions:
+                  type: array
+                  description: Actions
+                  items:
+                    type: string
+                error:
+                  type: string
+                  description: Last error
+                errors:
+                  type: array
+                  description: Errors
+                  items:
+                    type: string
+                updated:
+                  type: integer
+                  minimum: 0
+                  description: Updated Hosts count
+                added:
+                  type: integer
+                  minimum: 0
+                  description: Added Hosts count
+                deleted:
+                  type: integer
+                  minimum: 0
+                  description: Deleted Hosts count
+                delete:
+                  type: integer
+                  minimum: 0
+                  description: About to delete Hosts count
+                pods:
+                  type: array
+                  description: Pods
+                  items:
+                    type: string
+                fqdns:
+                  type: array
+                  description: Pods FQDNs
+                  items:
+                    type: string
+                endpoint:
+                  type: string
+                  description: Endpoint
+                generation:
+                  type: integer
+                  minimum: 0
+                  description: Generation
+                normalized:
+                  type: object
+                  description: Normalized CHI
+                  x-kubernetes-preserve-unknown-fields: true
             spec:
               type: object
               description: |

--- a/charts/altinity-clickhouse-operator/crds/CustomResourceDefinition-clickhouseoperatorconfigurations.clickhouse.altinity.com.yaml
+++ b/charts/altinity-clickhouse-operator/crds/CustomResourceDefinition-clickhouseoperatorconfigurations.clickhouse.altinity.com.yaml
@@ -85,7 +85,7 @@ spec:
                   description: ClickHouse server configuration `<quota>...</quota>` for any <user>
                 chConfigUserDefaultNetworksIP:
                   type: array
-                  description: ClickHouse server configuration `<networks><ip>...</ip></netrworks>` for any <user>
+                  description: ClickHouse server configuration `<networks><ip>...</ip></networks>` for any <user>
                   items:
                     type: string
                 chConfigUserDefaultPassword:
@@ -116,7 +116,7 @@ spec:
                   description: boolean, allows logs to stderr
                 alsologtostderr:
                   type: string
-                  description: booleanm allows logs to stderr and files both
+                  description: boolean allows logs to stderr and files both
                 v:
                   type: string
                   description: verbosity level of clickhouse-operator log, default - 1 max - 9

--- a/charts/altinity-clickhouse-operator/hacks/sync-yamls.sh
+++ b/charts/altinity-clickhouse-operator/hacks/sync-yamls.sh
@@ -41,7 +41,9 @@ mkdir "${CHART_PATH}/crds"  "${CHART_PATH}/tmp"
 
 extract_resources "${REPO_URL}/clickhouse-operator-install-bundle.yaml" "${CHART_PATH}/tmp"
 cp ${CHART_PATH}/tmp/CustomResourceDefinition-* ${CHART_PATH}/crds/
-cat ${CHART_PATH}/tmp/ClusterRole* > ${CHART_PATH}/templates/rbac.yaml
+cat ${CHART_PATH}/tmp/ClusterRoleBinding-* > ${CHART_PATH}/templates/rbac.yaml
+echo "---" >> ${CHART_PATH}/templates/rbac.yaml
+cat ${CHART_PATH}/tmp/ClusterRole-* >> ${CHART_PATH}/templates/rbac.yaml
 cp ${CHART_PATH}/tmp/ConfigMap-* ${CHART_PATH}/templates/generated/
 cp ${CHART_PATH}/tmp/Deployment-clickhouse-operator.yaml ${CHART_PATH}/templates/generated/
 cp ${CHART_PATH}/tmp/Service-clickhouse-operator-metrics.yaml ${CHART_PATH}/templates/generated/

--- a/charts/altinity-clickhouse-operator/hacks/sync-yamls.sh
+++ b/charts/altinity-clickhouse-operator/hacks/sync-yamls.sh
@@ -3,7 +3,7 @@
 set -o errexit
 set -o nounset
 
-CHART_PATH=../
+CHART_PATH=..
 BUILD_PATH="${CHART_PATH}/../../build"
 
 APP_VERSION=$(cat "${CHART_PATH}/Chart.yaml" | grep appVersion | cut -d : -f 2 | xargs)
@@ -35,12 +35,19 @@ function extract_resources() {
   IFS=$OLDIFS
 }
 
-rm -rf "${CHART_PATH}/crds" "${CHART_PATH}/templates/generated"
-mkdir "${CHART_PATH}/crds" "${CHART_PATH}/templates/generated"
+rm -rf "${CHART_PATH}/crds"  "${CHART_PATH}/tmp"
+mkdir "${CHART_PATH}/crds"  "${CHART_PATH}/tmp"
 
-extract_resources "${REPO_URL}/clickhouse-operator-install-crd.yaml" "${CHART_PATH}/crds"
-extract_resources "${REPO_URL}/clickhouse-operator-install-deployment.yaml" "${CHART_PATH}/templates/generated"
-extract_resources "${REPO_URL}/clickhouse-operator-install-service.yaml" "${CHART_PATH}/templates/generated"
+
+extract_resources "${REPO_URL}/clickhouse-operator-install-bundle.yaml" "${CHART_PATH}/tmp"
+cp ${CHART_PATH}/tmp/CustomResourceDefinition-* ${CHART_PATH}/crds/
+cat ${CHART_PATH}/tmp/ClusterRole* > ${CHART_PATH}/templates/rbac.yaml
+cp ${CHART_PATH}/tmp/ConfigMap-* ${CHART_PATH}/templates/generated/
+cp ${CHART_PATH}/tmp/Deployment-clickhouse-operator.yaml ${CHART_PATH}/templates/generated/
+cp ${CHART_PATH}/tmp/Service-clickhouse-operator-metrics.yaml ${CHART_PATH}/templates/generated/
+rm -rf "${CHART_PATH}/tmp"
+#extract_resources "${REPO_URL}/clickhouse-operator-install-deployment.yaml" "${CHART_PATH}/templates/generated"
+#extract_resources "${REPO_URL}/clickhouse-operator-install-service.yaml" "${CHART_PATH}/templates/generated"
 
 exit 1
 

--- a/charts/altinity-clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-files.yaml
+++ b/charts/altinity-clickhouse-operator/templates/generated/ConfigMap-etc-clickhouse-operator-files.yaml
@@ -18,11 +18,8 @@ data:
 
     # List of namespaces where clickhouse-operator watches for events.
     # Concurrently running operators should watch on different namespaces
-    #watchNamespaces:
-    #  - dev
-    #  - test
-    #  - info
-    #  - onemore
+    #watchNamespaces: ["dev", "test"]
+    watchNamespaces: []
 
     ################################################
     ##
@@ -105,8 +102,8 @@ data:
     # 3. DROP DNS CACHE
     # User with such credentials can be specified in additional ClickHouse .xml config files,
     # located in `chUsersConfigsPath` folder
-    chUsername: clickhouse_operator
-    chPassword: clickhouse_operator_password
+    chUsername: "clickhouse_operator"
+    chPassword: "clickhouse_operator_password"
 
     # Location of k8s Secret with username and password to be used by operator to connect to ClickHouse instances
     # Can be used instead of explicitly specified username and password
@@ -165,4 +162,15 @@ data:
     #  LabelClusterScopeCycleIndex
     #  LabelClusterScopeCycleOffset
     appendScopeLabels: "no"
+
+    ################################################
+    ##
+    ## Pod management parameters
+    ##
+    ################################################
+    # Grace period for Pod termination.
+    # How many seconds to wait between sending
+    # SIGTERM and SIGKILL during Pod termination process.
+    # Increase this number is case of slow shutdown.
+    terminationGracePeriod: 30
 {{ end }}

--- a/charts/altinity-clickhouse-operator/templates/rbac.yaml
+++ b/charts/altinity-clickhouse-operator/templates/rbac.yaml
@@ -11,6 +11,7 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "altinity-clickhouse-operator.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+---
 apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRole
 metadata:

--- a/charts/altinity-clickhouse-operator/templates/rbac.yaml
+++ b/charts/altinity-clickhouse-operator/templates/rbac.yaml
@@ -1,21 +1,4 @@
 apiVersion: rbac.authorization.k8s.io/v1
-kind: ClusterRole
-metadata:
-  name: {{ include "altinity-clickhouse-operator.serviceAccountName" . }}
-  namespace: {{ .Release.Namespace }}
-rules:
-  - apiGroups:
-      - '*'
-    resources:
-      - '*'
-    verbs:
-      - '*'
-  - nonResourceURLs:
-      - '*'
-    verbs:
-      - '*'
----
-apiVersion: rbac.authorization.k8s.io/v1
 kind: ClusterRoleBinding
 metadata:
   name: {{ include "altinity-clickhouse-operator.serviceAccountName" . }}
@@ -28,3 +11,148 @@ subjects:
   - kind: ServiceAccount
     name: {{ include "altinity-clickhouse-operator.serviceAccountName" . }}
     namespace: {{ .Release.Namespace }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: ClusterRole
+metadata:
+  name: {{ include "altinity-clickhouse-operator.serviceAccountName" . }}
+  namespace: {{ .Release.Namespace }}
+rules:
+  - apiGroups:
+      - ""
+    resources:
+      - configmaps
+      - services
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - endpoints
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - events
+    verbs:
+      - create
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumeclaims
+    verbs:
+      - delete
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - ""
+    resources:
+      - persistentvolumes
+      - pods
+    verbs:
+      - get
+      - list
+      - patch
+      - update
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - statefulsets
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+      - list
+      - watch
+  - apiGroups:
+      - apps
+    resources:
+      - replicasets
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - apps
+    resourceNames:
+      - clickhouse-operator
+    resources:
+      - deployments
+    verbs:
+      - get
+      - patch
+      - update
+      - delete
+  - apiGroups:
+      - policy
+    resources:
+      - poddisruptionbudgets
+    verbs:
+      - create
+      - delete
+      - get
+      - patch
+      - update
+      - list
+      - watch
+  - apiGroups:
+      - clickhouse.altinity.com
+    resources:
+      - clickhouseinstallations
+    verbs:
+      - delete
+      - get
+      - patch
+      - update
+  - apiGroups:
+      - clickhouse.altinity.com
+    resources:
+      - clickhouseinstallations
+      - clickhouseinstallationtemplates
+      - clickhouseoperatorconfigurations
+    verbs:
+      - get
+      - list
+      - watch
+  - apiGroups:
+      - clickhouse.altinity.com
+    resources:
+      - clickhouseinstallations/finalizers
+      - clickhouseinstallationtemplates/finalizers
+      - clickhouseoperatorconfigurations/finalizers
+    verbs:
+      - update
+  - apiGroups:
+      - clickhouse.altinity.com
+    resources:
+      - clickhouseinstallations/status
+      - clickhouseinstallationtemplates/status
+      - clickhouseoperatorconfigurations/status
+    verbs:
+      - create
+      - delete
+      - get
+      - update
+      - patch
+  - apiGroups:
+      - ""
+    resources:
+      - secrets
+    verbs:
+      - get
+      - list


### PR DESCRIPTION
This PR will upgrade the altinity-clickhouse-operator chart to be compatible with altinity 0.16.1.
They introduced many changes in 0.16.1 which also changed the file names / files that were used in sync-yamls.sh as source.

The helm chart does work and got tested by me, but i'm not sure if the sync-yamls.sh fits your automation needs.