### PR TITLE
fix(log4shell): bump gradle-cache app version

### DIFF
--- a/charts/gradle-cache/Chart.yaml
+++ b/charts/gradle-cache/Chart.yaml
@@ -3,8 +3,8 @@ name: gradle-cache
 description: |-
   Helm chart to deploy [gradle-cache](https://docs.gradle.com/build-cache-node/).
 type: application
-version: 0.0.14
-appVersion: "9.9"
+version: 0.0.15
+appVersion: "10.3"
 home: https://github.com/slamdev/helm-charts/tree/master/charts/gradle-cache
 icon: https://gradle.org/icon/favicon-32x32.png
 maintainers:

--- a/charts/gradle-cache/README.md
+++ b/charts/gradle-cache/README.md
@@ -1,6 +1,6 @@
 # gradle-cache
 
-![Version: 0.0.14](https://img.shields.io/badge/Version-0.0.14-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 9.9](https://img.shields.io/badge/AppVersion-9.9-informational?style=flat-square)
+![Version: 0.0.15](https://img.shields.io/badge/Version-0.0.15-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 10.3](https://img.shields.io/badge/AppVersion-10.3-informational?style=flat-square)
 
 Helm chart to deploy [gradle-cache](https://docs.gradle.com/build-cache-node/).
 


### PR DESCRIPTION
The talk of the town at the moment....

[Version History](https://docs.gradle.com/build-cache-node/#version_history)
10.3
16th December 2021
[FIX] Update Alpine Docker base image to mitigate vulnerability for possible code execution

[FIX] Update Netty to mitigate vulnerability for "Inconsistent Interpretation of HTTP Requests"

10.2
15th December 2021
[FIX] Upgrade Log4j to 2.16.0 (see https://security.gradle.com/advisory/2021-11)

10.1
13th December 2021
[FIX] Mitigate log4j2 RCE vulnerability (see https://security.gradle.com/advisory/2021-11)

