### PR TITLE
gradle cache secret should be conditional

### DIFF
--- a/charts/gradle-cache/Chart.yaml
+++ b/charts/gradle-cache/Chart.yaml
@@ -3,7 +3,7 @@ name: gradle-cache
 description: |-
   Helm chart to deploy [gradle-cache](https://docs.gradle.com/build-cache-node/).
 type: application
-version: 0.1.2
+version: 0.1.3
 appVersion: "11.0"
 home: https://github.com/slamdev/helm-charts/tree/master/charts/gradle-cache
 icon: https://gradle.org/icon/favicon-32x32.png

--- a/charts/gradle-cache/templates/secret.yaml
+++ b/charts/gradle-cache/templates/secret.yaml
@@ -1,3 +1,4 @@
+{{- if .Values.configSecret.create }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -7,3 +8,4 @@ metadata:
     {{- include "gradle-cache.labels" . | nindent 4 }}
 data:
   config.yaml: {{ .Values.configSecret.content | b64enc | quote }}
+{{- end }}  


### PR DESCRIPTION
The values.yaml and the doc contains a key `configSecret.create` but it is unused. This is supposed to specifies whether a secret should be created. Now with the help of this pull request it does that indeed. 
