### PR TITLE
Add: pod annotations, command and args

### DIFF
--- a/charts/altinity-clickhouse-operator/Chart.yaml
+++ b/charts/altinity-clickhouse-operator/Chart.yaml
@@ -7,7 +7,7 @@ description: |-
 
   Refer to operator repo for additional information.
 type: application
-version: 0.0.13
+version: 0.0.14
 appVersion: 0.18.1
 home: https://github.com/slamdev/helm-charts/tree/master/charts/altinity-clickhouse-operator
 icon: https://artifacthub.io/image/2d6aa29c-c74f-4bff-bede-ba7e6e0315a7@2x

--- a/charts/altinity-clickhouse-operator/README.md
+++ b/charts/altinity-clickhouse-operator/README.md
@@ -29,6 +29,8 @@ Refer to operator repo for additional information.
 | metrics.image.repository | string | `"altinity/metrics-exporter"` | image repository |
 | metrics.image.tag | string | `""` | image tag (chart's appVersion value will be used if not set) |
 | metrics.resources | object | `{}` | custom resource configuration |
+| metrics.command | list | `nil` | command for metrics-exporter container |
+| metrics.args | list | `nil` | args for metrics-exporter container |
 | nameOverride | string | `""` | override name of the chart |
 | nodeSelector | object | `{}` | node for scheduler pod assignment |
 | operator.env | list | `[]` | additional environment variables for the deployment |
@@ -36,6 +38,9 @@ Refer to operator repo for additional information.
 | operator.image.repository | string | `"altinity/clickhouse-operator"` | image repository |
 | operator.image.tag | string | `""` | image tag (chart's appVersion value will be used if not set) |
 | operator.resources | object | `{}` | custom resource configuration |
+| operator.command | list | `nil` | command for operator container |
+| operator.args | list | `nil` | args for operator container |
+| podAnnotations | object | `nil` | additional pod annotations |
 | serviceAccount.annotations | object | `{}` | annotations to add to the service account |
 | serviceAccount.create | bool | `true` | specifies whether a service account should be created |
 | serviceAccount.name | string | `nil` | the name of the service account to use; if not set and create is true, a name is generated using the fullname template |

--- a/charts/altinity-clickhouse-operator/templates/generated/Deployment-clickhouse-operator.yaml
+++ b/charts/altinity-clickhouse-operator/templates/generated/Deployment-clickhouse-operator.yaml
@@ -32,6 +32,9 @@ spec:
         checksum/files: {{ include (print $.Template.BasePath "/generated/ConfigMap-etc-clickhouse-operator-files.yaml") . | sha256sum }}
         checksum/templatesd-files: {{ include (print $.Template.BasePath "/generated/ConfigMap-etc-clickhouse-operator-templatesd-files.yaml") . | sha256sum }}
         checksum/usersd-files: {{ include (print $.Template.BasePath "/generated/ConfigMap-etc-clickhouse-operator-usersd-files.yaml") . | sha256sum }}
+        {{- if .Values.podAnnotations }}
+        {{- toYaml .Values.podAnnotations | nindent 8 }}
+        {{- end }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:
@@ -58,6 +61,18 @@ spec:
         - name: {{ .Chart.Name }}
           image: "{{ .Values.operator.image.repository }}:{{ include "altinity-clickhouse-operator.operator.tag" . }}"
           imagePullPolicy: {{ .Values.operator.image.pullPolicy }}
+          {{- if .Values.operator.command }}
+          command:
+            {{- range $value := .Values.operator.command }}
+            - {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.operator.args }}
+          args:
+            {{- range $value := .Values.operator.args }}
+            - {{ $value | quote }}
+            {{- end }}
+          {{- end }}
           volumeMounts:
             - name: etc-clickhouse-operator-folder
               mountPath: /etc/clickhouse-operator
@@ -126,6 +141,18 @@ spec:
         - name: metrics-exporter
           image: "{{ .Values.metrics.image.repository }}:{{ include "altinity-clickhouse-operator.metrics.tag" . }}"
           imagePullPolicy: {{ .Values.metrics.image.pullPolicy }}
+          {{- if .Values.metrics.command }}
+          command:
+            {{- range $value := .Values.metrics.command }}
+            - {{ $value | quote }}
+            {{- end }}
+          {{- end }}
+          {{- if .Values.metrics.args }}
+          args:
+            {{- range $value := .Values.metrics.args }}
+            - {{ $value | quote }}
+            {{- end }}
+          {{- end }}
           volumeMounts:
             - name: etc-clickhouse-operator-folder
               mountPath: /etc/clickhouse-operator


### PR DESCRIPTION
This PR:

- Additional annotations can be added to pods' metadata
- Custom command and args can be set for containers