### PR TITLE
feat(charts/bazel-remote): bump image version to `v2.3.8`

### DIFF
--- a/charts/bazel-remote/Chart.yaml
+++ b/charts/bazel-remote/Chart.yaml
@@ -3,8 +3,8 @@ name: bazel-remote
 description: |-
   Helm chart to deploy [bazel-remote](https://github.com/buchgr/bazel-remote).
 type: application
-version: 0.0.3
-appVersion: v2.2.0
+version: 0.0.4
+appVersion: v2.3.8
 home: https://github.com/slamdev/helm-charts/tree/master/charts/bazel-remote
 icon: https://bazel.build/images/bazel-icon.svg
 maintainers:

--- a/charts/bazel-remote/README.md
+++ b/charts/bazel-remote/README.md
@@ -1,6 +1,6 @@
 # bazel-remote
 
-![Version: 0.0.3](https://img.shields.io/badge/Version-0.0.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.2.0](https://img.shields.io/badge/AppVersion-v2.2.0-informational?style=flat-square)
+![Version: 0.0.4](https://img.shields.io/badge/Version-0.0.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v2.3.8](https://img.shields.io/badge/AppVersion-v2.3.8-informational?style=flat-square)
 
 Helm chart to deploy [bazel-remote](https://github.com/buchgr/bazel-remote).
 
@@ -17,7 +17,7 @@ Helm chart to deploy [bazel-remote](https://github.com/buchgr/bazel-remote).
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` | affinity for scheduler pod assignment |
-| conf | string | `"# https://github.com/buchgr/bazel-remote#example-configuration-file\ndir: /cache\nmax_size: 50\nexperimental_remote_asset_api: true\naccess_log_level: none\nport: 8080\ngrpc_port: 9092"` | bazel-remote config to provision inside of the container |
+| conf | string | `"# https://github.com/buchgr/bazel-remote#example-configuration-file\ndir: /data\nmax_size: 50\nexperimental_remote_asset_api: true\naccess_log_level: none\nport: 8080\ngrpc_port: 9092"` | bazel-remote config to provision inside of the container |
 | containerPorts | list | `[{"containerPort":8080,"name":"http"},{"containerPort":9092,"name":"grpc"}]` | ports exposed by container |
 | deploymentAnnotations | object | `{}` | annotations to add to the deployment |
 | env | list | `[]` | additional environment variables for the deployment |

--- a/charts/bazel-remote/values.yaml
+++ b/charts/bazel-remote/values.yaml
@@ -85,7 +85,7 @@ affinity: {}
 # volumeMounts -- additional volume mounts
 volumeMounts: []
 #   - name: cache
-#     mountPath: /cache
+#     mountPath: /data
 
 # volumes -- additional volumes
 volumes: []
@@ -137,7 +137,7 @@ serviceMonitor:
 # conf -- bazel-remote config to provision inside of the container
 conf: |-
   # https://github.com/buchgr/bazel-remote#example-configuration-file
-  dir: /cache
+  dir: /data
   max_size: 50
   experimental_remote_asset_api: true
   access_log_level: none


### PR DESCRIPTION
- bump bazel-remote image version to `v2.3.8`
- fix helm install failure when using default values
  > change `/cache` dir to `/data`(default in bazel-remote image)
- bump chart version to `0.0.4`