### PR TITLE
feat(gradle-cache) Adds support for Ingress class name

### DIFF
--- a/charts/gradle-cache/Chart.yaml
+++ b/charts/gradle-cache/Chart.yaml
@@ -3,7 +3,7 @@ name: gradle-cache
 description: |-
   Helm chart to deploy [gradle-cache](https://docs.gradle.com/build-cache-node/).
 type: application
-version: 0.1.3
+version: 0.1.4
 appVersion: "11.0"
 home: https://github.com/slamdev/helm-charts/tree/master/charts/gradle-cache
 icon: https://gradle.org/icon/favicon-32x32.png

--- a/charts/gradle-cache/README.md
+++ b/charts/gradle-cache/README.md
@@ -31,6 +31,7 @@ Helm chart to deploy [gradle-cache](https://docs.gradle.com/build-cache-node/).
 | ingress.enabled | bool | `false` | enables Ingress for gradle-cache |
 | ingress.hosts | list | `[]` | ingress accepted hostnames |
 | ingress.tls | list | `[]` | ingress TLS configuration |
+| ingress.ingressClassName | string | `""` | ingress name of the IngressClass cluster resource |
 | livenessProbe.httpGet.path | string | `"/"` | path for liveness probe |
 | livenessProbe.httpGet.port | string | `"http"` | port for liveness probe |
 | nameOverride | string | `""` | override name of the chart |

--- a/charts/gradle-cache/templates/ingress.yaml
+++ b/charts/gradle-cache/templates/ingress.yaml
@@ -19,6 +19,9 @@ metadata:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
+{{- with .Values.ingress.ingressClassName }}
+  ingressClassName: {{ . | quote }}
+{{- end }}
 {{- if .Values.ingress.tls }}
   tls:
   {{- range .Values.ingress.tls }}

--- a/charts/gradle-cache/values.yaml
+++ b/charts/gradle-cache/values.yaml
@@ -86,6 +86,8 @@ ingress:
   #  - secretName: chart-example-tls
   #    hosts:
   #      - chart-example.local
+  # ingress.ingressClassName -- ingress name of the IngressClass cluster resource
+  ingressClassName: ""
 
 # resources -- custom resource configuration
 resources: {}


### PR DESCRIPTION
Adds Ingress class name support (cf. https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.21/#ingressspec-v1-networking-k8s-io)