### PR TITLE
Support custom initContainer image in gradle-proxy

### DIFF
--- a/charts/gradle-cache/Chart.yaml
+++ b/charts/gradle-cache/Chart.yaml
@@ -3,7 +3,7 @@ name: gradle-cache
 description: |-
   Helm chart to deploy [gradle-cache](https://docs.gradle.com/build-cache-node/).
 type: application
-version: 0.1.4
+version: 0.1.5
 appVersion: "11.0"
 home: https://github.com/slamdev/helm-charts/tree/master/charts/gradle-cache
 icon: https://gradle.org/icon/favicon-32x32.png

--- a/charts/gradle-cache/README.md
+++ b/charts/gradle-cache/README.md
@@ -32,6 +32,8 @@ Helm chart to deploy [gradle-cache](https://docs.gradle.com/build-cache-node/).
 | ingress.hosts | list | `[]` | ingress accepted hostnames |
 | ingress.tls | list | `[]` | ingress TLS configuration |
 | ingress.ingressClassName | string | `""` | ingress name of the IngressClass cluster resource |
+| initContainer.image.repository | string | `"busybox"` | image repository for initContainer |
+| initContainer.image.tag | string | `"1.33.0"` | image tag for initContainer |
 | livenessProbe.httpGet.path | string | `"/"` | path for liveness probe |
 | livenessProbe.httpGet.port | string | `"http"` | port for liveness probe |
 | nameOverride | string | `""` | override name of the chart |

--- a/charts/gradle-cache/templates/deployment.yaml
+++ b/charts/gradle-cache/templates/deployment.yaml
@@ -24,7 +24,7 @@ spec:
         {{- toYaml .Values.podSecurityContext | nindent 8 }}
       initContainers:
         - name: config-mounter
-          image: busybox:1.33.0
+          image: "{{ .Values.initContainer.image.repository }}:{{ .Values.initContainer.image.tag }}"
           command:
              - sh
              - -ce

--- a/charts/gradle-cache/values.yaml
+++ b/charts/gradle-cache/values.yaml
@@ -6,6 +6,13 @@ image:
   # image.pullPolicy -- image pull policy
   pullPolicy: IfNotPresent
 
+initContainer:
+  image:
+    # initContainer.image.repository -- image repository for initContainer
+    repository: busybox
+    # initContainer.image.tag -- image tag for initContainer
+    tag: "1.33.0"
+
 # imagePullSecrets -- image pull secret for private images
 imagePullSecrets: []
 # nameOverride -- override name of the chart


### PR DESCRIPTION
Factoring out hard-coded repo and tag into values file.

It is useful for those running everything from private mirrors.