### PR TITLE
feat(gradle-cache): automatic rollout of the deployment after a configuration update

### DIFF
--- a/charts/gradle-cache/Chart.yaml
+++ b/charts/gradle-cache/Chart.yaml
@@ -3,7 +3,7 @@ name: gradle-cache
 description: |-
   Helm chart to deploy [gradle-cache](https://docs.gradle.com/build-cache-node/).
 type: application
-version: 0.1.5
+version: 0.2.0
 appVersion: "11.0"
 home: https://github.com/slamdev/helm-charts/tree/master/charts/gradle-cache
 icon: https://gradle.org/icon/favicon-32x32.png

--- a/charts/gradle-cache/templates/deployment.yaml
+++ b/charts/gradle-cache/templates/deployment.yaml
@@ -14,6 +14,8 @@ spec:
     metadata:
       labels:
         {{- include "gradle-cache.selectorLabels" . | nindent 8 }}
+      annotations:
+        checksum/secret: {{ include (print $.Template.BasePath "/secret.yaml") . | sha256sum }}
     spec:
     {{- with .Values.imagePullSecrets }}
       imagePullSecrets:


### PR DESCRIPTION
Based on https://helm.sh/docs/howto/charts_tips_and_tricks/#automatically-roll-deployments